### PR TITLE
Using the FQDN instead of hostname

### DIFF
--- a/lib/security/cyclone_pam.py
+++ b/lib/security/cyclone_pam.py
@@ -166,7 +166,7 @@ def start_server(pamh, argv):
     # create main uri using random generated port
     global PORT
     PORT = server.server_address[1]
-    host_ip = socket.gethostname()
+    host_ip = socket.getfqdn()
     global MY_URI
     MY_URI = 'http://{0}:{1}'.format(host_ip, str(PORT))
     try:


### PR DESCRIPTION
As an example, IFB VM are named like vm4242 but can only be reach from outside with the fqdn : vm4242.france-bioinformatique.fr
